### PR TITLE
Update jinja2 version to 3.1.3 and remove unnecessary [dev] spec from…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ python-multipart==0.0.18
 sqlalchemy==2.0.23
 pydantic==2.5.2
 aiofiles==23.2.1
-jinja2==3.1.2
+jinja2==3.1.3
 python-dotenv==1.0.0
 requests==2.32.2 
-python-json-logger[dev]==3.2.0
+python-json-logger==3.2.0
 nltk==3.8.1


### PR DESCRIPTION
… python-json-logger